### PR TITLE
Rdpmc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: collide
 
-CFLAGS := -O2 -g --std=gnu99
+CFLAGS := -O2 -g --std=gnu99 -D_GNU_SOURCE
 
 clean:
 	rm -f collide


### PR DESCRIPTION
Take a look anyway: this is how I got rdpmc instructions to work. I also warm up 10x times before timing which I found made results more stable on my Arrendale.

NB the "bind" _is_ important. It seems the perf drivers only allow user-mode access to the PMC counters for the CPU that you called the perf routine on. If you don't do the bind (try it!) then sometimes you'll get a segfault on the "rdpmc" instruction (which is strictly an "illegal instruction") as you get migrated to another CPU who hasn't had the user-mode PMC bit set (phew!).

There's probably a better way! This is a nice compromise compared to agner's kernel library if we can get it to work.
